### PR TITLE
Fix grammar in jsonSpecs

### DIFF
--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/creo-cd.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/creo-cd.json
@@ -1,6 +1,6 @@
 {
   "spec" : {
-    "function_description" : "Change Creo's working directory",
+    "function_description" : "Change Creos working directory",
     "command" : "creo",
     "function" : "cd",
     "request" : [ {

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/creo-delete_files.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/creo-delete_files.json
@@ -7,7 +7,7 @@
       "name" : "dirname",
       "type" : "string",
       "description" : "Directory name",
-      "default" : "Creo's current working directory"
+      "default" : "Creos current working directory"
     }, {
       "name" : "filename",
       "type" : "string",

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/creo-get_std_color.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/creo-get_std_color.json
@@ -1,6 +1,6 @@
 {
   "spec" : {
-    "function_description" : "Get one of Creo's standard colors",
+    "function_description" : "Get one of Creos standard colors",
     "command" : "creo",
     "function" : "get_std_color",
     "request" : [ {

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/creo-list_dirs.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/creo-list_dirs.json
@@ -1,6 +1,6 @@
 {
   "spec" : {
-    "function_description" : "List subdirectories of Creo's current working directory",
+    "function_description" : "List subdirectories of Creos current working directory",
     "command" : "creo",
     "function" : "list_dirs",
     "request" : [ {

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/creo-list_files.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/creo-list_files.json
@@ -1,6 +1,6 @@
 {
   "spec" : {
-    "function_description" : "List files in Creo's current working directory",
+    "function_description" : "List files in Creos current working directory",
     "command" : "creo",
     "function" : "list_files",
     "request" : [ {

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/creo-pwd.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/creo-pwd.json
@@ -1,6 +1,6 @@
 {
   "spec" : {
-    "function_description" : "Return Creo's current working directory",
+    "function_description" : "Return Creos current working directory",
     "command" : "creo",
     "function" : "pwd",
     "request" : [ ],

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/creo-set_std_color.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/creo-set_std_color.json
@@ -1,6 +1,6 @@
 {
   "spec" : {
-    "function_description" : "Set one of Creo's standard colors",
+    "function_description" : "Set one of Creos standard colors",
     "command" : "creo",
     "function" : "set_std_color",
     "request" : [ {

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/dimension-set_text.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/dimension-set_text.json
@@ -18,7 +18,7 @@
       "name" : "text",
       "type" : "depends on data type",
       "description" : "Dimension text",
-      "default" : "Sets the dimension's text to @D if missing"
+      "default" : "Sets the dimensions text to @D if missing"
     }, {
       "name" : "encoded",
       "type" : "boolean",

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/drawing-create.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/drawing-create.json
@@ -12,7 +12,7 @@
       "name" : "drawing",
       "type" : "string",
       "description" : "New drawing name",
-      "default" : "A name derived from the model's instance name"
+      "default" : "A name derived from the models instance name"
     }, {
       "name" : "template",
       "type" : "string",

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/drawing-create_gen_view.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/drawing-create_gen_view.json
@@ -37,7 +37,7 @@
       "name" : "scale",
       "type" : "double",
       "description" : "View scale",
-      "default" : "The sheet's scale"
+      "default" : "The sheets scale"
     }, {
       "name" : "display_data",
       "type" : "object:ViewDisplayData",

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/drawing-create_proj_view.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/drawing-create_proj_view.json
@@ -13,7 +13,7 @@
       "name" : "view",
       "type" : "string",
       "description" : "New view name",
-      "default" : "Creo's default name for a new view"
+      "default" : "Creos default name for a new view"
     }, {
       "name" : "sheet",
       "type" : "integer",

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/drawing-load_symbol_def.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/drawing-load_symbol_def.json
@@ -11,8 +11,8 @@
     }, {
       "name" : "symbol_dir",
       "type" : "string",
-      "description" : "Directory containing the symbol file; if relative, assumed to be relative to Creo's current working directory",
-      "default" : "Creo's current working directory"
+      "description" : "Directory containing the symbol file; if relative, assumed to be relative to Creos current working directory",
+      "default" : "Creos current working directory"
     }, {
       "name" : "symbol_file",
       "type" : "string",

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/drawing-set_sheet_format.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/drawing-set_sheet_format.json
@@ -18,7 +18,7 @@
       "name" : "dirname",
       "type" : "string",
       "description" : "Directory name containing the format file",
-      "default" : "Creo's current working directory"
+      "default" : "Creos current working directory"
     }, {
       "name" : "file",
       "type" : "string",

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/familytable-exists.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/familytable-exists.json
@@ -17,7 +17,7 @@
     "response" : [ {
       "name" : "exists",
       "type" : "boolean",
-      "description" : "Whether the instance exists in the model's family table; returns false if there is no family table in the model"
+      "description" : "Whether the instance exists in the models family table; returns false if there is no family table in the model"
     } ]
   },
   "examples" : [ {

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/feature-param_exists.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/feature-param_exists.json
@@ -22,7 +22,7 @@
       "name" : "params",
       "type" : "array:string",
       "description" : "List of parameter names",
-      "default" : "The param parameter is used; if both are empty, then it checks for any parameter's existence"
+      "default" : "The param parameter is used; if both are empty, then it checks for any parameters existence"
     } ],
     "response" : [ {
       "name" : "exists",

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/file-assemble.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/file-assemble.json
@@ -7,7 +7,7 @@
       "name" : "dirname",
       "type" : "string",
       "description" : "Directory name",
-      "default" : "Creo's current working directory"
+      "default" : "Creos current working directory"
     }, {
       "name" : "file",
       "type" : "string",

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/file-get_transform.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/file-get_transform.json
@@ -17,12 +17,12 @@
       "name" : "csys",
       "type" : "string",
       "description" : "Coordinate system on the component to calculate the transform for",
-      "default" : "The component's default coordinate system"
+      "default" : "The components default coordinate system"
     } ],
     "response" : [ {
       "name" : "transform",
       "type" : "object:JLTransform",
-      "description" : "The 3D transform from the assembly to the component's coordinate system"
+      "description" : "The 3D transform from the assembly to the components coordinate system"
     } ]
   },
   "examples" : [ {

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/file-list_instances.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/file-list_instances.json
@@ -1,6 +1,6 @@
 {
   "spec" : {
-    "function_description" : "List instances in a model's family table",
+    "function_description" : "List instances in a models family table",
     "command" : "file",
     "function" : "list_instances",
     "request" : [ {

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/file-load_material_file.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/file-load_material_file.json
@@ -14,7 +14,7 @@
       "name" : "dirname",
       "type" : "string",
       "description" : "Directory name containing the material file",
-      "default" : "Creo's 'pro_material_dir' config setting, or search path, or current working directory"
+      "default" : "Creos 'pro_material_dir' config setting, or search path, or current working directory"
     }, {
       "name" : "material",
       "type" : "string",

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/file-massprops.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/file-massprops.json
@@ -3,7 +3,7 @@
     "function_description" : "Get mass property information about a model",
     "command" : "file",
     "function" : "massprops",
-    "notes" : [ "PTC's description of coord_sys_inertia: \"The inertia matrix with respect to coordinate frame:(element ij is the integral of x_i x_j over the object)\"", "PTC's description of coord_sys_inertia_tensor: \"The inertia tensor with respect to coordinate frame:CoordSysInertiaTensor = trace(CoordSysInertia) * identity - CoordSysInertia\"" ],
+    "notes" : [ "PTCs description of coord_sys_inertia: \"The inertia matrix with respect to coordinate frame:(element ij is the integral of x_i x_j over the object)\"", "PTCs description of coord_sys_inertia_tensor: \"The inertia tensor with respect to coordinate frame:CoordSysInertiaTensor = trace(CoordSysInertia) * identity - CoordSysInertia\"" ],
     "request" : [ {
       "name" : "file",
       "type" : "string",
@@ -29,15 +29,15 @@
     }, {
       "name" : "ctr_grav_inertia_tensor",
       "type" : "object:JLInertia",
-      "description" : "Model's Inertia Tensor translated to center of gravity."
+      "description" : "Models Inertia Tensor translated to center of gravity."
     }, {
       "name" : "coord_sys_inertia",
       "type" : "object:JLInertia",
-      "description" : "Model's Inertia Matrix with respect to the coordinate frame."
+      "description" : "Models Inertia Matrix with respect to the coordinate frame."
     }, {
       "name" : "coord_sys_inertia_tensor",
       "type" : "object:JLInertia",
-      "description" : "Model's Inertia Tensor with respect to the coordinate frame."
+      "description" : "Models Inertia Tensor with respect to the coordinate frame."
     } ]
   },
   "examples" : [ {

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/file-open.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/file-open.json
@@ -7,7 +7,7 @@
       "name" : "dirname",
       "type" : "string",
       "description" : "Directory name",
-      "default" : "Creo's current working directory"
+      "default" : "Creos current working directory"
     }, {
       "name" : "file",
       "type" : "string",

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/file-set_length_units.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/file-set_length_units.json
@@ -3,7 +3,7 @@
     "function_description" : "Set the current length units for a model",
     "command" : "file",
     "function" : "set_length_units",
-    "notes" : [ "This will search the model's available Unit Systems for the first one which contains the given length unit" ],
+    "notes" : [ "This will search the models available Unit Systems for the first one which contains the given length unit" ],
     "request" : [ {
       "name" : "file",
       "type" : "string",
@@ -17,7 +17,7 @@
     }, {
       "name" : "convert",
       "type" : "boolean",
-      "description" : "Whether to convert the model's length values to the new units (true) or leave them the same value (false)",
+      "description" : "Whether to convert the models length values to the new units (true) or leave them the same value (false)",
       "default" : "true"
     } ],
     "response" : [ ]

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/file-set_mass_units.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/file-set_mass_units.json
@@ -3,7 +3,7 @@
     "function_description" : "Set the current mass units for a model",
     "command" : "file",
     "function" : "set_mass_units",
-    "notes" : [ "This will search the model's available Unit Systems for the first one which contains the given mass unit" ],
+    "notes" : [ "This will search the models available Unit Systems for the first one which contains the given mass unit" ],
     "request" : [ {
       "name" : "file",
       "type" : "string",
@@ -17,7 +17,7 @@
     }, {
       "name" : "convert",
       "type" : "boolean",
-      "description" : "Whether to convert the model's mass values to the new units (true) or leave them the same value (false)",
+      "description" : "Whether to convert the models mass values to the new units (true) or leave them the same value (false)",
       "default" : "true"
     } ],
     "response" : [ ]

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/interface-export_3dpdf.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/interface-export_3dpdf.json
@@ -13,7 +13,7 @@
       "name" : "filename",
       "type" : "string",
       "description" : "Destination file name.  May also contain a path to the file.",
-      "default" : "The model name with the appropriate file extension, in Creo's working directory"
+      "default" : "The model name with the appropriate file extension, in Creos working directory"
     }, {
       "name" : "height",
       "type" : "double",
@@ -33,7 +33,7 @@
       "name" : "dirname",
       "type" : "string",
       "description" : "Destination directory",
-      "default" : "Creo's current working directory"
+      "default" : "Creos current working directory"
     }, {
       "name" : "use_drawing_settings",
       "type" : "boolean",

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/interface-export_file.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/interface-export_file.json
@@ -19,12 +19,12 @@
       "name" : "filename",
       "type" : "string",
       "description" : "Destination file name.  May also contain a path to the file.",
-      "default" : "The model name with the appropriate file extension, in Creo's working directory"
+      "default" : "The model name with the appropriate file extension, in Creos working directory"
     }, {
       "name" : "dirname",
       "type" : "string",
       "description" : "Destination directory",
-      "default" : "Creo's current working directory"
+      "default" : "Creos current working directory"
     }, {
       "name" : "geom_flags",
       "type" : "string",

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/interface-export_image.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/interface-export_image.json
@@ -18,7 +18,7 @@
       "name" : "filename",
       "type" : "string",
       "description" : "Destination file name.  May also contain a path to the file.",
-      "default" : "The model name with the appropriate file extension, in Creo's working directory"
+      "default" : "The model name with the appropriate file extension, in Creos working directory"
     }, {
       "name" : "height",
       "type" : "double",

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/interface-export_pdf.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/interface-export_pdf.json
@@ -13,7 +13,7 @@
       "name" : "filename",
       "type" : "string",
       "description" : "Destination file name.  May also contain a path to the file.",
-      "default" : "The model name with the appropriate file extension, in Creo's working directory"
+      "default" : "The model name with the appropriate file extension, in Creos working directory"
     }, {
       "name" : "height",
       "type" : "double",
@@ -33,7 +33,7 @@
       "name" : "dirname",
       "type" : "string",
       "description" : "Destination directory",
-      "default" : "Creo's current working directory"
+      "default" : "Creos current working directory"
     }, {
       "name" : "use_drawing_settings",
       "type" : "boolean",

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/interface-export_program.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/interface-export_program.json
@@ -1,6 +1,6 @@
 {
   "spec" : {
-    "function_description" : "Export a model's program to a file",
+    "function_description" : "Export a models program to a file",
     "command" : "interface",
     "function" : "export_program",
     "request" : [ {

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/interface-import_file.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/interface-import_file.json
@@ -14,7 +14,7 @@
       "name" : "dirname",
       "type" : "string",
       "description" : "Source directory",
-      "default" : "Creo's current working directory"
+      "default" : "Creos current working directory"
     }, {
       "name" : "filename",
       "type" : "string",

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/interface-import_program.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/interface-import_program.json
@@ -8,7 +8,7 @@
       "name" : "dirname",
       "type" : "string",
       "description" : "Source directory",
-      "default" : "Creo's current working directory"
+      "default" : "Creos current working directory"
     }, {
       "name" : "filename",
       "type" : "string",

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/interface-plot.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/interface-plot.json
@@ -12,7 +12,7 @@
       "name" : "dirname",
       "type" : "string",
       "description" : "Destination directory",
-      "default" : "Creo's current working directory"
+      "default" : "Creos current working directory"
     }, {
       "name" : "driver",
       "type" : "string",

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/note-exists.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/note-exists.json
@@ -17,7 +17,7 @@
       "name" : "names",
       "type" : "array:string",
       "description" : "List of note names",
-      "default" : "The name parameter is used; if both are empty, then it checks for any note's existence"
+      "default" : "The name parameter is used; if both are empty, then it checks for any notes existence"
     } ],
     "response" : [ {
       "name" : "exists",

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/object-BomChild.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/object-BomChild.json
@@ -14,7 +14,7 @@
   }, {
     "name" : "path",
     "type" : "array:integer",
-    "description" : "Creo's component path for the component"
+    "description" : "Creos component path for the component"
   }, {
     "name" : "transform",
     "type" : "object:JLTransform",

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/object-DimSelectData.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/object-DimSelectData.json
@@ -26,6 +26,6 @@
   }, {
     "name" : "relation_id",
     "type" : "integer",
-    "description" : "Relation ID for the dimension's model"
+    "description" : "Relation ID for the dimensions model"
   } ]
 }

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/object-ServiceStatus.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/object-ServiceStatus.json
@@ -12,6 +12,6 @@
   }, {
     "name" : "expired",
     "type" : "boolean",
-    "description" : "Whether the user's session has expired"
+    "description" : "Whether the users session has expired"
   } ]
 }

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/parameter-exists.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/parameter-exists.json
@@ -17,7 +17,7 @@
       "name" : "names",
       "type" : "array:string",
       "description" : "List of parameter names",
-      "default" : "The name parameter is used; if both are empty, then it checks for any parameter's existence"
+      "default" : "The name parameter is used; if both are empty, then it checks for any parameters existence"
     } ],
     "response" : [ {
       "name" : "exists",

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/server-pwd.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/server-pwd.json
@@ -1,6 +1,6 @@
 {
   "spec" : {
-    "function_description" : "Return the server's execution directory",
+    "function_description" : "Return the servers execution directory",
     "command" : "server",
     "function" : "pwd",
     "notes" : [ "*** WARNING *** WARNING *** WARNING ***", "-", "The endpoint for this function must be /server, not /creoson", "-", "*** WARNING *** WARNING *** WARNING ***" ],

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/view-save.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/view-save.json
@@ -1,6 +1,6 @@
 {
   "spec" : {
-    "function_description" : "Save a model's current orientation as a new view",
+    "function_description" : "Save a models current orientation as a new view",
     "command" : "view",
     "function" : "save",
     "request" : [ {

--- a/creoson-server/web/assets/creoson_stuff/jsonSpecs/windchill-authorize.json
+++ b/creoson-server/web/assets/creoson_stuff/jsonSpecs/windchill-authorize.json
@@ -1,17 +1,17 @@
 {
   "spec" : {
-    "function_description" : "Set user's Windchill login/password",
+    "function_description" : "Set users Windchill login/password",
     "command" : "windchill",
     "function" : "authorize",
     "request" : [ {
       "name" : "user",
       "type" : "string",
-      "description" : "User's Windchill login",
+      "description" : "Users Windchill login",
       "required" : true
     }, {
       "name" : "password",
       "type" : "string",
-      "description" : "User's Windchill password",
+      "description" : "Users Windchill password",
       "required" : true
     } ],
     "response" : [ ]


### PR DESCRIPTION
Remove " 's " from possessive nouns. This may seem like nitpicking at grammar, but this can cause errors while parsing these files while automating development, proper use of apostrophes aside. 