### PR TITLE
Fix duplicate drive letter in dirname returned by file/get_active

### DIFF
--- a/creoson-core/src/com/simplifiedlogic/nitro/jlink/impl/JlinkUtils.java
+++ b/creoson-core/src/com/simplifiedlogic/nitro/jlink/impl/JlinkUtils.java
@@ -602,10 +602,14 @@ public class JlinkUtils {
     public static String getPath(CallModel m) throws jxthrowable {
     	CallModelDescriptor desc = m.getDescr();
     	String drive = desc.getDevice();
-    	if (drive!=null && drive.length()>0)
-    		return drive + ':' + desc.getPath();
-    	else
-    		return desc.getPath();
+    	String path = desc.getPath();
+    	if (drive!=null && drive.length()>0) {
+
+    		String drivePrefix = drive.substring(0, 1) + ':';
+    		if (!path.regionMatches(true, 0, drivePrefix, 0, drivePrefix.length()))
+    			return drivePrefix + path;
+    	}
+    	return path;
     }
 
     /**


### PR DESCRIPTION
When Creo's getDevice() returns a drive letter (e.g. 'C') and getPath() already returns a full path including the drive letter (e.g. 'C:/Users/...'), the old code would prepend the drive letter again, producing 'C:C:/Users/...'.

Fixed by checking if the path already starts with the drive letter before prepending it.

Fixes #135